### PR TITLE
Bugfix/fix auth decorator python3

### DIFF
--- a/djangohmac/sign.py
+++ b/djangohmac/sign.py
@@ -186,7 +186,7 @@ class Hmac(object):
             InvalidSignature
         """
         hmac_token_server = self.make_hmac_for(key_name, request.body)
-        if signature != hmac_token_server:
+        if six.b(signature) != six.b(hmac_token_server):
             raise InvalidSignature('Signatures are different: {0} {1}'.format(
                 signature, hmac_token_server
             ))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py33,py34}-django{17,18}
+envlist = {py27,py33,py34,py35,py36,py37}-django{17,18,19,110,111,20,21,22,30}
 
 [testenv]
 commands = py.test tests
@@ -10,7 +10,14 @@ setenv =
 deps =
     django17: Django>=1.7, <1.8
     django18: Django>=1.8, <1.9
-    pytest==2.6.4
+    django19: Django>=1.9, <1.10
+    django110: Django>=1.10, <1.11
+    django111: Django>=1.11, <2.0
+    {py33,py34,py35,py36,py37}-django20: Django>=2.0, <2.1
+    {py33,py34,py35,py36,py37}-django21: Django>=2.1, <2.2
+    {py33,py34,py35,py36,py37}-django22: Django>=2.2, <3.0
+    {py33,py34,py35,py36,py37}-django30: Django>=3.0, <3.1
+    pytest==4.6.7
     pytest-cov
     pytest-pep8
     pytest-flakes


### PR DESCRIPTION
Fix issue #25 by casting both header signature and computed signature to the same type.